### PR TITLE
Add files via upload

### DIFF
--- a/Omar_Brandan_47375.sql
+++ b/Omar_Brandan_47375.sql
@@ -484,6 +484,9 @@ SELECT * FROM user WHERE user = 'luisA';
 
 /* TCL */
 
+SELECT @@autocommit;
+SET @@autocommit = 0;
+
 START TRANSACTION;
 DELETE FROM Delivery WHERE DeliveryID = 3;
 DELETE FROM Delivery WHERE DeliveryID = 7;


### PR DESCRIPTION
Se agregaron dos líneas previas al START TRANSACTION:

SELECT @@autocommit;
SET @@autocommit = 0;

para que las operaciones DML no se ejecuten automáticamente.